### PR TITLE
Make it possible to zoom beyond tile zoom limit

### DIFF
--- a/frontend/src/components/maps/LayerSelector/LayerSelector.stories.tsx
+++ b/frontend/src/components/maps/LayerSelector/LayerSelector.stories.tsx
@@ -16,9 +16,9 @@ const meta = {
   args: {
     onZoomChange: fn(),
   },
-  render: (args) => (
-    <MapContainer center={[POSITION[0], POSITION[1]]} zoom={13} maxZoom={18} scrollWheelZoom={true} className="map" zoomControl={false}>
-      <LayerSelector {...args} />
+  render: () => (
+    <MapContainer center={[POSITION[0], POSITION[1]]} zoom={18} maxZoom={25} scrollWheelZoom={true} className="map" zoomControl={false}>
+      <LayerSelector />
     </MapContainer>
   ),
 } satisfies Meta<typeof LayerSelector>;
@@ -26,20 +26,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {
+export const Default: Story = {
   args: { },
-  parameters: {
-    viewport: {
-      defaultViewport: "responsive",
-    },
-  },
-};
-
-export const Phone: Story = {
-  args: { },
-  parameters: {
-    viewport: {
-      defaultViewport: "mobile1",
-    },
-  },
 };

--- a/frontend/src/components/maps/LayerSelector/LayerSelector.tsx
+++ b/frontend/src/components/maps/LayerSelector/LayerSelector.tsx
@@ -2,16 +2,8 @@ import { LayersControl, TileLayer } from "react-leaflet";
 import VectorTileLayer from "react-leaflet-vector-tile-layer";
 import { getMapTilerKey } from "@/utils/env";
 
-interface IProps {
-  onZoomChange: (zoom: number) => void;
-}
-
-export const LayerSelector = (props: IProps) => {
+export const LayerSelector = () => {
   const mapTilerKey = getMapTilerKey();
-
-  const handleMaxZoomChange = (zoom: number) => {
-    props.onZoomChange(zoom);
-  };
 
   return (
     <LayersControl position="topright">
@@ -20,9 +12,6 @@ export const LayerSelector = (props: IProps) => {
           attribution='&copy; <a href="https://github.com/umonkey/treemap/wiki/Data-contribution" target="_blank">Tree Map</a> contributors'
           styleUrl={`https://api.maptiler.com/maps/streets-v2/style.json?key=${mapTilerKey}`}
           accessToken={mapTilerKey}
-          eventHandlers={{
-            add: () => handleMaxZoomChange(25),
-          }}
         />
       </LayersControl.BaseLayer>
 
@@ -30,12 +19,8 @@ export const LayerSelector = (props: IProps) => {
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          eventHandlers={{
-            add: () => handleMaxZoomChange(25),
-          }}
           maxZoom={25}
-          // @ts-expect-error TS2322
-          mazNativeZoom={18}
+          maxNativeZoom={19}
         />
       </LayersControl.BaseLayer>
 
@@ -44,12 +29,8 @@ export const LayerSelector = (props: IProps) => {
           attribution='&copy; Google Maps'
           url="http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}"
           subdomains={["mt0", "mt1", "mt2", "mt3"]}
-          eventHandlers={{
-            add: () => handleMaxZoomChange(25),
-          }}
           maxZoom={25}
-          // @ts-expect-error TS2322
-          mazNativeZoom={18}
+          maxNativeZoom={22}
         />
       </LayersControl.BaseLayer>
     </LayersControl>

--- a/frontend/src/components/maps/LayerSelector/LayerSelector.tsx
+++ b/frontend/src/components/maps/LayerSelector/LayerSelector.tsx
@@ -31,8 +31,11 @@ export const LayerSelector = (props: IProps) => {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           eventHandlers={{
-            add: () => handleMaxZoomChange(18),
+            add: () => handleMaxZoomChange(25),
           }}
+          maxZoom={25}
+          // @ts-expect-error TS2322
+          mazNativeZoom={18}
         />
       </LayersControl.BaseLayer>
 
@@ -42,8 +45,11 @@ export const LayerSelector = (props: IProps) => {
           url="http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}"
           subdomains={["mt0", "mt1", "mt2", "mt3"]}
           eventHandlers={{
-            add: () => handleMaxZoomChange(18),
+            add: () => handleMaxZoomChange(25),
           }}
+          maxZoom={25}
+          // @ts-expect-error TS2322
+          mazNativeZoom={18}
         />
       </LayersControl.BaseLayer>
     </LayersControl>

--- a/frontend/src/components/maps/MapBase/MapBase.tsx
+++ b/frontend/src/components/maps/MapBase/MapBase.tsx
@@ -41,7 +41,17 @@ export const MapBase = (props: IProps) => {
       height: "100%",
       width: "100%",
     }}>
-      <MapContainer ref={mapRef} center={[props.center.lat, props.center.lon]} zoom={zoom} maxZoom={maxZoom} scrollWheelZoom={true} className="map" zoomControl={false}>
+      <MapContainer
+        ref={mapRef}
+        center={[props.center.lat, props.center.lon]}
+        zoom={zoom}
+        maxZoom={maxZoom}
+        // @ts-expect-error TS2322
+        maxNativeZoom={25}
+        scrollWheelZoom={true}
+        className="map"
+        zoomControl={false}
+      >
         <MapEventHandler onViewChange={handleViewChange} />
         <LayerSelector onZoomChange={handleZoomChange} />
 

--- a/frontend/src/components/maps/MapBase/MapBase.tsx
+++ b/frontend/src/components/maps/MapBase/MapBase.tsx
@@ -26,9 +26,7 @@ interface IProps {
 export const MapBase = (props: IProps) => {
   const {
     handleViewChange,
-    handleZoomChange,
     mapRef,
-    maxZoom,
     ref,
     zoom,
   } = useMapBase({
@@ -45,15 +43,13 @@ export const MapBase = (props: IProps) => {
         ref={mapRef}
         center={[props.center.lat, props.center.lon]}
         zoom={zoom}
-        maxZoom={maxZoom}
-        // @ts-expect-error TS2322
-        maxNativeZoom={25}
+        maxZoom={25}
         scrollWheelZoom={true}
         className="map"
         zoomControl={false}
       >
         <MapEventHandler onViewChange={handleViewChange} />
-        <LayerSelector onZoomChange={handleZoomChange} />
+        <LayerSelector />
 
         {props.children}
       </MapContainer>

--- a/frontend/src/components/maps/MapBase/hooks.ts
+++ b/frontend/src/components/maps/MapBase/hooks.ts
@@ -18,7 +18,6 @@ interface IProps {
 export const useMapBase = (props: IProps) => {
   const [center, setCenter] = useState<ILatLng>(props.center);
   const [zoom] = useState<number>(props.zoom);
-  const [maxZoom, setMaxZoom] = useState<number>(25);
   const { setMapState } = useMapState();
 
   const ref = useRef(null);
@@ -47,13 +46,6 @@ export const useMapBase = (props: IProps) => {
     return () => mainBus.off("pan_to", handler);
   }, []);
 
-  // react-leaflet does not update properties dynamically, so we need to do it manually.
-  useEffect(() => {
-    if (mapRef.current) {
-      mapRef.current.setMaxZoom(maxZoom);
-    }
-  }, [maxZoom]);
-
   useEffect(() => {
     if (!ref.current) {
       console.debug("Ref empty, not installing resize observer.");
@@ -74,11 +66,6 @@ export const useMapBase = (props: IProps) => {
     return () => resizeObserver.disconnect();
   }, [ref]);
 
-  const handleZoomChange = (zoom: number) => {
-    console.debug(`Max zoom changed to ${zoom}.`);
-    setMaxZoom(zoom);
-  };
-
   const handleViewChange = (view: IMapView) => {
     setMapState(view);
   };
@@ -87,8 +74,6 @@ export const useMapBase = (props: IProps) => {
     ref,
     mapRef,
     zoom,
-    maxZoom,
     handleViewChange,
-    handleZoomChange,
   };
 };


### PR DESCRIPTION
- Set maxZoom and maxNativeZoom for tile layers to 25.
- When zooming beyond max native zoom, new tiles stop loading.  Have to zoom out to load them, then zoom back in.

Closes #50