### PR TITLE
Feature/adding null default option of tree state

### DIFF
--- a/backend/src/services/app/mod.rs
+++ b/backend/src/services/app/mod.rs
@@ -83,7 +83,7 @@ impl AppState {
                 height: Some(0.0),
                 circumference: Some(0.0),
                 diameter: Some(0.0),
-                state: "healthy".to_string(),
+                state: Some("healthy".to_string()),
             }),
         }
     }

--- a/backend/src/types/responses/new_tree_defaults_response.rs
+++ b/backend/src/types/responses/new_tree_defaults_response.rs
@@ -9,7 +9,7 @@ pub struct NewTreeDefaultsResponse {
     pub height: Option<f64>,
     pub circumference: Option<f64>,
     pub diameter: Option<f64>,
-    pub state: String,
+    pub state: Option<String>,
 }
 
 impl NewTreeDefaultsResponse {
@@ -20,7 +20,7 @@ impl NewTreeDefaultsResponse {
             height: None,
             circumference: None,
             diameter: None,
-            state: "healthy".to_string(),
+            state: None,
         }
     }
 }

--- a/backend/src/types/search_query.rs
+++ b/backend/src/types/search_query.rs
@@ -147,7 +147,6 @@ impl SearchQuery {
             if self.unknown && tree.state != "unknown" {
                 return false;
             }
-
         }
 
         if self.incomplete && Self::is_tree_incomplete(tree) {
@@ -174,7 +173,7 @@ impl SearchQuery {
     }
 
     fn is_tree_incomplete(tree: &TreeRecord) -> bool {
-        tree.state.is_none()
+        tree.state == "unknown"
             || tree.height.is_none()
             || tree.circumference.is_none()
             || tree.diameter.is_none()
@@ -208,7 +207,7 @@ mod tests {
             height: None,
             circumference: None,
             diameter: None,
-            state: None,
+            state: "unknown".to_string(),
             added_at: 0,
             updated_at: 0,
             added_by: 0,

--- a/frontend/src/components/elements/TreeStateSelector/TreeStateSelector.tsx
+++ b/frontend/src/components/elements/TreeStateSelector/TreeStateSelector.tsx
@@ -36,6 +36,7 @@ export const TreeStateSelector = (props: IProps) => {
         <MenuItem value="dead">{locale.stateDead()}</MenuItem>
         <MenuItem value="stomp">{locale.stateStomp()}</MenuItem>
         <MenuItem value="gone">{locale.stateGone()}</MenuItem>
+        <MenuItem value="unknown">{locale.stateUnknown()}</MenuItem>
       </Select>
     </FormControl>
   );

--- a/frontend/src/locale/index.ts
+++ b/frontend/src/locale/index.ts
@@ -95,6 +95,10 @@ class EnglishLocale {
     return "Gone";
   }
 
+  public stateUnknown(): string {
+    return "State is not known";
+  }
+
   public searchTreesPlaceholder(count: number): string {
     if (count === 0) {
       return "Search trees...";
@@ -303,6 +307,10 @@ class RussianLocale extends EnglishLocale {
 
   public stateGone(): string {
     return "Исчезло";
+  }
+
+  public stateUnknown(): string {
+    return "Состояние не определено";
   }
 
   public searchTreesPlaceholder(count: number) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -159,7 +159,7 @@ export interface ITreeDefaults {
   height: number | null;
   circumference: number | null;
   diameter: number | null;
-  state: string;
+  state: string | null;
 }
 
 export interface IFileUploadRequest {


### PR DESCRIPTION
Mapping from aerial imagery, i.e. preliminary mapping tree coordinates, in most cases is insufficient for ruling on `tree.state` -- only for coordinates. 

Hence, a neutral category is necessary:
- ideally, `Null`
- if that is not possible for `String` values in Rust/React, `"unknown"` value is okay-ish (I did this way, because... I do not know both and  Rust/React=)

@umonkey help wanted!

PS: adding one value required changing or editing code in ~35 places with lots of boilerplate. I'd create a very low-priority refactoring issue for "folding" repetitive "ifs and [test]s" IF it is possible. -> Is it possible?