### PR TITLE
Add a better tree mapper mode

### DIFF
--- a/backend/src/actions/add_trees_action.rs
+++ b/backend/src/actions/add_trees_action.rs
@@ -1,9 +1,9 @@
-///! This endpoint receives requests to add one new tree.
+//! This endpoint receives requests to add one new tree.
 
-use actix_web::{post, web::Data, web::Json, HttpRequest};
-use serde::Deserialize;
 use crate::services::AppState;
 use crate::types::{AddTreeRequest, LatLon, Result, TreeList};
+use actix_web::{post, web::Data, web::Json, HttpRequest};
+use serde::Deserialize;
 
 fn default_state() -> String {
     "unknown".to_string()

--- a/backend/src/actions/add_trees_action.rs
+++ b/backend/src/actions/add_trees_action.rs
@@ -1,8 +1,13 @@
+///! This endpoint receives requests to add one new tree.
+
 use actix_web::{post, web::Data, web::Json, HttpRequest};
 use serde::Deserialize;
-
 use crate::services::AppState;
 use crate::types::{AddTreeRequest, LatLon, Result, TreeList};
+
+fn default_state() -> String {
+    "unknown".to_string()
+}
 
 #[derive(Debug, Deserialize)]
 struct RequestPayload {
@@ -12,6 +17,7 @@ struct RequestPayload {
     pub height: Option<f64>,
     pub circumference: Option<f64>,
     pub diameter: Option<f64>,
+    #[serde(default = "default_state")]
     pub state: String,
     pub year: Option<i64>,
     pub address: Option<String>,

--- a/frontend/src/lib/components/ExplorerModeLink.svelte
+++ b/frontend/src/lib/components/ExplorerModeLink.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { locale } from '$lib/locale';
+	import { modeStore } from '$lib/stores/modeStore';
+	import { routes, goto } from '$lib/routes';
+
+	const handleClick = (e: Event) => {
+		e.preventDefault();
+
+		modeStore.set('explorer');
+		console.log('[mode] Entered Explorer Mode');
+
+		goto(routes.map());
+	};
+</script>
+
+<a href={routes.map()} onclick={handleClick}>{locale.enterExplorerMode()}</a>

--- a/frontend/src/lib/components/ExplorerModeLink.svelte
+++ b/frontend/src/lib/components/ExplorerModeLink.svelte
@@ -2,11 +2,12 @@
 	import { locale } from '$lib/locale';
 	import { modeStore } from '$lib/stores/modeStore';
 	import { routes, goto } from '$lib/routes';
+	import { ModeEnum } from '$lib/enums';
 
 	const handleClick = (e: Event) => {
 		e.preventDefault();
 
-		modeStore.set('explorer');
+		modeStore.set(ModeEnum.Explorer);
 		console.log('[mode] Entered Explorer Mode');
 
 		goto(routes.map());

--- a/frontend/src/lib/components/LeftSideBar.svelte
+++ b/frontend/src/lib/components/LeftSideBar.svelte
@@ -27,7 +27,7 @@
 			</a>
 		</li>
 		<li>
-			<a href="/map">
+			<a href={routes.map()}>
 				<span class="icon"><MapIcon /></span>
 				<span>{locale.sideExplore()}</span>
 			</a>

--- a/frontend/src/lib/components/MapperModeLink.svelte
+++ b/frontend/src/lib/components/MapperModeLink.svelte
@@ -2,11 +2,12 @@
 	import { locale } from '$lib/locale';
 	import { modeStore } from '$lib/stores/modeStore';
 	import { routes, goto } from '$lib/routes';
+	import { ModeEnum } from '$lib/enums';
 
 	const handleClick = (e: Event) => {
 		e.preventDefault();
 
-		modeStore.set('mapper');
+		modeStore.set(ModeEnum.Mapper);
 		console.log('[mode] Entered Mapper Mode');
 
 		goto(routes.map());

--- a/frontend/src/lib/components/MapperModeLink.svelte
+++ b/frontend/src/lib/components/MapperModeLink.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { locale } from '$lib/locale';
+	import { modeStore } from '$lib/stores/modeStore';
+	import { routes, goto } from '$lib/routes';
+
+	const handleClick = (e: Event) => {
+		e.preventDefault();
+
+		modeStore.set('mapper');
+		console.log('[mode] Entered Mapper Mode');
+
+		goto(routes.map());
+	};
+</script>
+
+<a href={routes.map()} onclick={handleClick}>{locale.enterMapperMode()}</a>

--- a/frontend/src/lib/components/forms/StateEditor.svelte
+++ b/frontend/src/lib/components/forms/StateEditor.svelte
@@ -8,7 +8,7 @@
 
 	const { tree, onClose } = $props();
 
-	let value = $state<string | null>(tree.state);
+	let value = $state<string>(tree.state ?? 'unknown');
 
 	const onSave = async () => {
 		const res = await apiClient.updateTreeState(tree.id, value);
@@ -33,7 +33,7 @@
 <div class="form">
 	<label for="control">{locale.measureState()}</label>
 	<div class="row">
-		<StateInput {value} label={false} onChange={(v: string | null) => (value = v)} />
+		<StateInput {value} label={false} onChange={(v: string) => (value = v)} />
 	</div>
 	<div class="actions">
 		<Button label={locale.editSave()} type="submit" onClick={onSave} />

--- a/frontend/src/lib/components/forms/StateInput.svelte
+++ b/frontend/src/lib/components/forms/StateInput.svelte
@@ -7,15 +7,15 @@
 		label = true,
 		onChange
 	}: {
-		value: string | null;
+		value: string;
 		label?: boolean;
-		onChange: (value: string | null) => void;
+		onChange: (value: string) => void;
 	} = $props();
 
 	const handleChange = (e: Event) => {
 		if (e.target) {
 			const select = e.target as HTMLSelectElement;
-			onChange(select.value ?? null);
+			onChange(select.value ?? 'unknown');
 		}
 	};
 </script>
@@ -25,7 +25,7 @@
 		{#if label}<span>{locale.stateLabel()}</span>{/if}
 		<div class="group">
 			<select {value} onchange={handleChange}>
-				<option value="">{locale.stateUnknown()}</option>
+				<option value="unknown">{locale.stateUnknown()}</option>
 				<option value="healthy">{locale.stateHealthy()}</option>
 				<option value="sick">{locale.stateSick()}</option>
 				<option value="deformed">{locale.stateDeformed()}</option>

--- a/frontend/src/lib/components/index.ts
+++ b/frontend/src/lib/components/index.ts
@@ -1,0 +1,2 @@
+export { default as MapperModeLink } from './MapperModeLink.svelte';
+export { default as ExplorerModeLink } from './ExplorerModeLink.svelte';

--- a/frontend/src/lib/components/map/GalleryPreview.svelte
+++ b/frontend/src/lib/components/map/GalleryPreview.svelte
@@ -18,7 +18,11 @@
 				{/each}
 			</div>
 		{:else if res.status === 200 && res.data && res.data.files.length === 0}
-			No images for this tree.
+			<div class="images">
+				<a href={routes.treeDetails(tree.id)}>
+					<img src="/tree.jpg" alt="See how good is this tree." />
+				</a>
+			</div>
 		{:else}
 			Failed to load photos.
 		{/if}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,7 +1,8 @@
 import type { IMeResponse, ITree } from '$lib/types';
+import { ModeEnum } from '$lib/enums';
 
 export const DEFAULT_MAP_CENTER = [40.181389, 44.514444];
-export const DEFAULT_MODE = 'explorer';
+export const DEFAULT_MODE = ModeEnum.Explorer;
 
 export const MAX_BOUNDS = [
 	[

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,6 +1,7 @@
 import type { IMeResponse, ITree } from '$lib/types';
 
 export const DEFAULT_MAP_CENTER = [40.181389, 44.514444];
+export const DEFAULT_MODE = 'explorer';
 
 export const MAX_BOUNDS = [
 	[

--- a/frontend/src/lib/enums.ts
+++ b/frontend/src/lib/enums.ts
@@ -1,0 +1,4 @@
+export enum ModeEnum {
+	Mapper = 'mapper',
+	Explorer = 'explorer'
+}

--- a/frontend/src/lib/hooks/loadTree.ts
+++ b/frontend/src/lib/hooks/loadTree.ts
@@ -1,3 +1,15 @@
+// This hook should be used to get information on a specific single tree.
+//
+// The code returns the data from the store, if available.  If not, the data
+// is requested from the API, added to the store for future use, then returned.
+//
+// Usage in a component:
+//
+// ```javascript
+// const { loading, data, error, reload } = loadTree();
+// $effect(() => reload(id));
+// ```
+
 import type { IError, ISingleTree } from '$lib/types';
 import { apiClient } from '$lib/api';
 import { writable } from 'svelte/store';

--- a/frontend/src/lib/locale.ts
+++ b/frontend/src/lib/locale.ts
@@ -418,6 +418,18 @@ class EnglishLocale {
 	public centimeters(value: string): string {
 		return `${value} cm`;
 	}
+
+	public chooseFocus(): string {
+		return 'Please choose your focus';
+	}
+
+	public enterMapperMode(): string {
+		return 'Enter Tree Mapper';
+	}
+
+	public enterExplorerMode(): string {
+		return 'Enter Tree Explorer';
+	}
 }
 
 class RussianLocale extends EnglishLocale {
@@ -836,9 +848,21 @@ class RussianLocale extends EnglishLocale {
 	public centimeters(value: string): string {
 		return `${value} см`;
 	}
+
+	public chooseFocus(): string {
+		return 'Выберите фокус';
+	}
+
+	public enterMapperMode(): string {
+		return 'Войти в режим маппера';
+	}
+
+	public enterExplorerMode(): string {
+		return 'Войти в режим исследователя';
+	}
 }
 
-class ArmenianLocale {
+class ArmenianLocale extends EnglishLocale {
 	public appTitle(): string {
 		return 'Երևանի ծառեր';
 	}

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -7,6 +7,7 @@ export const routes = {
 	home: () => '/',
 	learn: () => '/learn',
 	map: () => '/map',
+	mapPreview: (id: string) => `/map?preview=${id}`,
 	newTrees: () => '/updates/new',
 	search: '/search',
 	searchAddress: (query: string) => `/map?q=addr:"${query}"`,

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -1,9 +1,12 @@
+export { goto } from '$app/navigation';
+
 export const routes = {
 	changedTrees: () => '/updates/changes',
 	comments: () => '/updates/comments',
 	file: (id: string) => `https://yerevan.treemaps.app/v1/files/${id}.jpg`,
 	home: () => '/',
 	learn: () => '/learn',
+	map: () => '/map',
 	newTrees: () => '/updates/new',
 	search: '/search',
 	searchAddress: (query: string) => `/map?q=addr:"${query}"`,

--- a/frontend/src/lib/stores/modeStore.ts
+++ b/frontend/src/lib/stores/modeStore.ts
@@ -1,6 +1,7 @@
 import { derived, writable } from 'svelte/store';
 import { DEFAULT_MODE } from '$lib/constants';
 import { ls } from '$lib/utils/localStorage';
+import { ModeEnum } from '$lib/enums';
 
 export const modeStore = writable<string>(ls.read('modeStore') || DEFAULT_MODE);
 
@@ -8,4 +9,4 @@ modeStore.subscribe((value: string) => {
 	ls.write('modeStore', value);
 });
 
-export const isMapperMode = derived(modeStore, ($modeStore) => $modeStore === 'mapper');
+export const isMapperMode = derived(modeStore, ($modeStore) => $modeStore === ModeEnum.Mapper);

--- a/frontend/src/lib/stores/modeStore.ts
+++ b/frontend/src/lib/stores/modeStore.ts
@@ -1,0 +1,9 @@
+import { writable } from 'svelte/store';
+import { DEFAULT_MODE } from '$lib/constants';
+import { ls } from '$lib/utils/localStorage';
+
+export const modeStore = writable<string>(ls.read('modeStore') || DEFAULT_MODE);
+
+modeStore.subscribe((value: string) => {
+	ls.write('modeStore', value);
+});

--- a/frontend/src/lib/stores/modeStore.ts
+++ b/frontend/src/lib/stores/modeStore.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import { DEFAULT_MODE } from '$lib/constants';
 import { ls } from '$lib/utils/localStorage';
 
@@ -7,3 +7,5 @@ export const modeStore = writable<string>(ls.read('modeStore') || DEFAULT_MODE);
 modeStore.subscribe((value: string) => {
 	ls.write('modeStore', value);
 });
+
+export const isMapperMode = derived(modeStore, ($modeStore) => $modeStore === 'mapper');

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import { rewriteHash } from '$lib/utils/rewrite';
 	import { locale } from '$lib/locale';
+	import { ExplorerModeLink, MapperModeLink } from '$lib/components';
 
 	import Header from '$lib/components/tree/Header.svelte';
 	import AppInstallButton from '$lib/components/AppInstallButton.svelte';
@@ -57,10 +58,32 @@
 	{/if}
 
 	<AppInstallButton />
+
+	<h2>{locale.chooseFocus()}</h2>
+
+	<ul>
+		<li><MapperModeLink /></li>
+		<li><ExplorerModeLink /></li>
+	</ul>
 </div>
 
 <style>
 	.home {
 		padding: 0 var(--gap);
+	}
+
+	h2 {
+		margin-top: 40px;
+		font-weight: 400;
+		font-size: 20px;
+		opacity: 0.75;
+	}
+
+	ul {
+		line-height: 1.5em;
+
+		li {
+			margin: 5px 0;
+		}
 	}
 </style>

--- a/frontend/src/routes/add/+page.svelte
+++ b/frontend/src/routes/add/+page.svelte
@@ -26,7 +26,7 @@
 	let height = $state<number | null>(null);
 	let diameter = $state<number | null>(null);
 	let circumference = $state<number | null>(null);
-	let treeState = $state<string | null>(null);
+	let treeState = $state<string>('unknown');
 	let notes = $state('');
 	let location = $state([data.lat, data.lng]);
 	let year = $state<number | null>(null);
@@ -92,7 +92,7 @@
 			value={circumference}
 			onChange={(value: number) => (circumference = value)}
 		/>
-		<StateInput value={treeState} onChange={(value: string | null) => (treeState = value)} />
+		<StateInput value={treeState} onChange={(value: string) => (treeState = value)} />
 		<YearInput value={year} onChange={(value: number) => (year = value)} />
 		<NotesInput bind:value={notes} />
 

--- a/frontend/src/routes/add/+page.svelte
+++ b/frontend/src/routes/add/+page.svelte
@@ -4,6 +4,7 @@
 	import { apiClient } from '$lib/api';
 	import { routes } from '$lib/routes';
 	import { locale } from '$lib/locale';
+	import { isMapperMode } from '$lib/stores/modeStore';
 
 	import AuthWrapper from '$lib/components/auth/AuthWrapper.svelte';
 	import Button from '$lib/components/forms/Button.svelte';
@@ -51,7 +52,11 @@
 			})
 			.then((res) => {
 				if (res.data) {
-					goto(routes.treeDetails(res.data.trees[0].id));
+					if ($isMapperMode) {
+						goto(routes.map());
+					} else {
+						goto(routes.treeDetails(res.data.trees[0].id));
+					}
 				} else {
 					console.error(`Error ${res.status} adding tree.`);
 					toast.push('Error adding tree.');

--- a/frontend/src/routes/map/+page.svelte
+++ b/frontend/src/routes/map/+page.svelte
@@ -6,20 +6,23 @@
 	import type { ITree } from '$lib/types';
 	import { locale } from '$lib/locale';
 	import { isMapperMode } from '$lib/stores/modeStore';
+	import { routes, goto } from '$lib/routes';
 
 	const { data } = $props();
 	const searchQuery = data.searchQuery;
-
-	let selectedTree = $state<ITree | undefined>(undefined);
+	const selectedTree = $derived(data.preview);
 
 	const title = searchQuery ? locale.mapTitleQuery(searchQuery) : locale.mapTitle();
 
+	// This is called when a user clicks a tree on the map.
+	// We need to show a preview, for this we redirect to the page
+	// with the right arguments.
 	const onChange = (tree: ITree) => {
-		selectedTree = tree;
+		goto(routes.mapPreview(tree.id));
 	};
 
 	const onClosePreview = () => {
-		selectedTree = undefined;
+		goto(routes.map());
 	};
 
 	const onMove = (center: number[], zoom: number) => {

--- a/frontend/src/routes/map/+page.svelte
+++ b/frontend/src/routes/map/+page.svelte
@@ -5,6 +5,7 @@
 	import { mapStore, mapCenter, mapZoom } from '$lib/stores/mapStore';
 	import type { ITree } from '$lib/types';
 	import { locale } from '$lib/locale';
+	import { isMapperMode } from '$lib/stores/modeStore';
 
 	const { data } = $props();
 	const searchQuery = data.searchQuery;
@@ -36,7 +37,15 @@
 <Header {title} />
 
 <div class="mapContainer">
-	<Map center={$mapCenter} zoom={$mapZoom} {onChange} {onMove} {searchQuery} canAdd={true} />
+	<Map
+		center={$mapCenter}
+		zoom={$mapZoom}
+		{onChange}
+		{onMove}
+		{searchQuery}
+		crosshair={$isMapperMode}
+		canAdd={$isMapperMode}
+	/>
 	<MapPreview tree={selectedTree} onClose={onClosePreview} />
 </div>
 

--- a/frontend/src/routes/map/+page.ts
+++ b/frontend/src/routes/map/+page.ts
@@ -4,10 +4,13 @@ export const load: Load = ({
 	url
 }): {
 	searchQuery: string | null;
+	preview: string | null;
 } => {
 	const searchQuery = url.searchParams.get('q');
+	const preview = url.searchParams.get('preview');
 
 	return {
-		searchQuery
+		searchQuery,
+		preview
 	};
 };

--- a/frontend/src/routes/tree/[id=treeid]/edit/+page.svelte
+++ b/frontend/src/routes/tree/[id=treeid]/edit/+page.svelte
@@ -24,7 +24,7 @@
 	let height = $state<number | null>(data.tree.height);
 	let diameter = $state<number | null>(data.tree.diameter);
 	let circumference = $state<number | null>(data.tree.circumference);
-	let treeState = $state<string | null>(data.tree.state);
+	let treeState = $state<string>(data.tree.state ?? 'unknown');
 	let notes = $state(data.tree.notes ?? '');
 	let location = $state([data.tree.lat, data.tree.lon]);
 	let year = $state<number | null>(data.tree.year);
@@ -77,7 +77,7 @@
 			value={circumference}
 			onChange={(value: number) => (circumference = value)}
 		/>
-		<StateInput value={treeState} onChange={(value: string | null) => (treeState = value)} />
+		<StateInput value={treeState} onChange={(value: string) => (treeState = value)} />
 		<YearInput value={year} onChange={(value: number | null) => (year = value)} />
 		<LocationInput bind:value={location} />
 		<NotesInput bind:value={notes} />

--- a/frontend/src/routes/tree/[id=treeid]/map/+page.svelte
+++ b/frontend/src/routes/tree/[id=treeid]/map/+page.svelte
@@ -13,10 +13,10 @@
 	const { data } = $props();
 	const tree = data.tree;
 
-	let selectedTree = $state<ITree | null>(null);
+	let selectedTree = $state<string | null>(null);
 
 	const onPreview = (tree: ITree) => {
-		selectedTree = tree;
+		selectedTree = tree.id;
 	};
 
 	const onClosePreview = () => {

--- a/frontend/src/routes/tree/[id=treeid]/map/+page.svelte
+++ b/frontend/src/routes/tree/[id=treeid]/map/+page.svelte
@@ -39,7 +39,7 @@
 		marker={[tree.lat, tree.lon]}
 		zoom={$mapZoom}
 		className="treeTab"
-		canAdd={true}
+		canAdd={false}
 		onChange={onPreview}
 	/>
 	<MapPreview tree={selectedTree} onClose={onClosePreview} />


### PR DESCRIPTION
- Changed default state to "unknown".
- Added mode switch buttons to the home page.
- Added modeStore to keep the mode between sessions.
- Show default picture in previews if no photos were added.
- Add preview id to the URL for consistency.
- Make Armenian translation base off English.
- Disable adding trees from a tree's map tab (confusing).
- Show a cross-hair when in the Tree Mapper mode.